### PR TITLE
Upgrading previous rskjs-util version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
-# rsk-utils
-> A collection of JS utility functions for RSK.
+# rskjs-util
+
+<!-- NPM Version -->
+<a href="https://www.npmjs.org/package/@rsksmart/rskjs-util">
+	<img src="http://img.shields.io/npm/v/@rsksmart/rskjs-util.svg"
+alt="NPM version" />
+</a>
+
+<!-- Gitter chat -->
+<a href="https://gitter.im/rsksmart/rskj">
+	<img src="https://badges.gitter.im/Join%20Chat.svg" alt="Gitter chat" />
+</a>
+
+A collection of JS utility functions for RSK.
 
 ## Addresses
 <a name="isAddress"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rsk-utils",
-  "version": "0.0.2",
+  "name": "@rsksmart/rskjs-util",
+  "version": "1.0.4",
   "description": "A collection of JS utility functions for RSK",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
`rskjs-util` package current version is in https://github.com/rsksmart/rskjs-util

After this PR:
1. Change `rskjs-util` repo name for `rskjs-util-deprecated` and archive it
2. Deprecate `rskjs-util` npm package
3. Change the name of this repo to `rskjs-util`
4. Publish on npm under `@rsksmart` org.

