### PR TITLE
remove unnecessary files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
**What:**

- Remove unnecessary files from npm package.

**Why:**

- There is no need of including source files on the npm package, just the `dist` folder.